### PR TITLE
Add missing introductions to diagnostic light practice

### DIFF
--- a/src/en/practice/p04-diagnostic-light.md
+++ b/src/en/practice/p04-diagnostic-light.md
@@ -1,3 +1,7 @@
+# Practice 4. Diagnostic Light
+
+This simplified diagnostic will help each partner note the main conditions, needs, and functions at the moment. Fill it out individually first, then discuss together.
+
 ### 1. Choose up to 5 key conditions that influence your life now:
 
 ____________________________________________________________

--- a/src/lt/practice/p04-diagnostic-light.md
+++ b/src/lt/practice/p04-diagnostic-light.md
@@ -1,3 +1,7 @@
+# 4 praktika. Supaprastinta diagnostika
+
+Ši supaprastinta diagnostika padės kiekvienam partneriui užfiksuoti pagrindines sąlygas, poreikius ir funkcijas šiuo metu. Pirmiausia užpildykite individualiai, tuomet aptarkite kartu.
+
 ### 1. Pasirinkite iki 5 pagrindinių sąlygų, kurios dabar veikia jūsų gyvenimą:
 
 ____________________________________________________________


### PR DESCRIPTION
## Summary
- restore practice title and description for Diagnostic Light in English and Lithuanian versions

## Testing
- `mkdocs build >/tmp/mkdocs.log && tail -n 20 /tmp/mkdocs.log`


------
https://chatgpt.com/codex/tasks/task_e_68bb376f547c83329b6152d527699e3c