### PR TITLE
Align cover taglines with terminology

### DIFF
--- a/src/en/theory/00-cover.md
+++ b/src/en/theory/00-cover.md
@@ -1,6 +1,6 @@
 # > CL/RF _ Couple Life Reflection Framework
 
-**A practical tool for understanding, visions, and changes in relationships**
+**A practical tool for diagnostics, vision, and change in relationships**
 
 _[Viktor Jevdokimov](https://www.linkedin.com/in/viktor-jevdokimov)_
 

--- a/src/lt/theory/00-cover.md
+++ b/src/lt/theory/00-cover.md
@@ -1,6 +1,6 @@
 # > CL/RF _ Couple Life Reflection Framework
 
-**Praktinis įrankis santykiams suprasti, vizijoms ir pokyčiams**
+**Praktinis įrankis diagnostikai, vizijai ir pokyčiams**
 
 _[Viktor Jevdokimov](https://www.linkedin.com/in/viktor-jevdokimov)_
 

--- a/src/ru/theory/00-cover.md
+++ b/src/ru/theory/00-cover.md
@@ -1,6 +1,6 @@
 # > CL/RF _ Couple Life Reflection Framework
 
-**Практический инструмент для понимания, визий и изменений в отношениях**
+**Практический инструмент для диагностики, визий и изменений в отношениях**
 
 _[Viktor Jevdokimov](https://www.linkedin.com/in/viktor-jevdokimov)_
 


### PR DESCRIPTION
## Summary
- Harmonized English cover tagline to use "diagnostics, vision, and change" terminology.
- Updated Lithuanian cover tagline for consistent terminology and case.
- Revised Russian cover tagline to replace "понимания" with "диагностики".

## Testing
- `make site`


------
https://chatgpt.com/codex/tasks/task_e_68bbc950d5a483329b236f5b68da1fc0